### PR TITLE
Added support for major to updateInternalDependencies config option

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -128,7 +128,9 @@ pkg-b @ version 1.0.1
   depends on pkg-a at range `^1.0.0
 ```
 
-Using `minor` allows consumers to more actively control their own deduplication of packages, and will allow them to install fewer versions if you have many interconnected packages. Using `patch` will mean consumers will more often be using more updated code, but may cause problems with deduplication.
+Similarly, if the option is set to `major`, it will only update the dependency when there is a major change.
+
+Using `minor` or `major` allows consumers to more actively control their own deduplication of packages, and will allow them to install fewer versions if you have many interconnected packages. Using `patch` will mean consumers will more often be using more updated code, but may cause problems with deduplication.
 
 Changesets will always update the dependency if it would leave the old semver range.
 

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -33,7 +33,7 @@ export default async function getChangelogEntry(
     updateInternalDependencies,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
-    updateInternalDependencies: "patch" | "minor";
+    updateInternalDependencies: "patch" | "minor" | "major";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ) {

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -32,7 +32,7 @@ export function shouldUpdateDependencyBasedOnConfig(
     minReleaseType,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
-    minReleaseType: "patch" | "minor";
+    minReleaseType: "patch" | "minor" | "major";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ): boolean {
@@ -47,5 +47,6 @@ export function shouldUpdateDependencyBasedOnConfig(
   if (depType === "peerDependencies") {
     shouldUpdate = !onlyUpdatePeerDependentsWhenOutOfRange;
   }
+
   return shouldUpdate;
 }

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -29,7 +29,7 @@ export default function versionPackage(
     bumpVersionsWithWorkspaceProtocolOnly,
     snapshot,
   }: {
-    updateInternalDependencies: "patch" | "minor";
+    updateInternalDependencies: "patch" | "minor" | "major";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
     snapshot?: string | boolean | undefined;

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -117,7 +117,7 @@
       "default": []
     },
     "updateInternalDependencies": {
-      "enum": ["patch", "minor"],
+      "enum": ["patch", "minor", "major"],
       "type": "string",
       "description": "The minimum bump type to trigger automatic update of internal dependencies that are part of the same release.",
       "default": "patch"

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -291,6 +291,15 @@ let correctCases: Record<string, CorrectCase> = {
       linked: [["pkg-a", "@pkg/a", "@pkg/b"], ["@pkg-other/a"]],
     },
   },
+  "update internal dependencies major": {
+    input: {
+      updateInternalDependencies: "major",
+    },
+    output: {
+      ...defaults,
+      updateInternalDependencies: "major",
+    },
+  },
   "update internal dependencies minor": {
     input: {
       updateInternalDependencies: "minor",
@@ -590,12 +599,12 @@ describe("parser errors", () => {
       'The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".'
     );
   });
-  test("updateInternalDependencies not patch or minor", () => {
+  test("updateInternalDependencies not patch, minor or major", () => {
     expect(() => {
-      unsafeParse({ updateInternalDependencies: "major" }, defaultPackages);
+      unsafeParse({ updateInternalDependencies: "none" }, defaultPackages);
     }).toThrowErrorMatchingInlineSnapshot(`
       "Some errors occurred when validating the changesets config:
-      The \`updateInternalDependencies\` option is set as "major" but can only be 'patch' or 'minor'"
+      The \`updateInternalDependencies\` option is set as "none" but can only be 'patch', 'minor' or 'major'"
     `);
   });
   test("ignore non-array", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -283,14 +283,14 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
 
   if (
     json.updateInternalDependencies !== undefined &&
-    !["patch", "minor"].includes(json.updateInternalDependencies)
+    !["patch", "minor", "major"].includes(json.updateInternalDependencies)
   ) {
     messages.push(
       `The \`updateInternalDependencies\` option is set as ${JSON.stringify(
         json.updateInternalDependencies,
         null,
         2
-      )} but can only be 'patch' or 'minor'`
+      )} but can only be 'patch', 'minor' or 'major'`
     );
   }
   if (json.ignore) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -77,7 +77,7 @@ export type Config = {
   /** Features enabled for Private packages */
   privatePackages: PrivatePackages;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
-  updateInternalDependencies: "patch" | "minor";
+  updateInternalDependencies: "patch" | "minor" | "major";
   ignore: ReadonlyArray<string>;
   /** This is supposed to be used with pnpm's `link-workspace-packages: false` and Berry's `enableTransparentWorkspaces: false` */
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
@@ -107,7 +107,7 @@ export type WrittenConfig = {
         tag?: boolean;
       };
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
-  updateInternalDependencies?: "patch" | "minor";
+  updateInternalDependencies?: "patch" | "minor" | "major";
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   snapshot?: {


### PR DESCRIPTION
Targetting fork's main to verify CI is 🟢 